### PR TITLE
Update urls after the repo move

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hpo-toolkit)
 ![PyPi downloads](https://img.shields.io/pypi/dm/hpo-toolkit.svg?label=Pypi%20downloads)
-![Build status](https://img.shields.io/github/actions/workflow/status/TheJacksonLaboratory/hpo-toolkit/python_ci.yml)
-[![GitHub release](https://img.shields.io/github/release/TheJacksonLaboratory/hpo-toolkit.svg)](https://github.com/TheJacksonLaboratory/hpo-toolkit/releases)
+![Build status](https://img.shields.io/github/actions/workflow/status/ielis/hpo-toolkit/python_ci.yml)
+[![GitHub release](https://img.shields.io/github/release/ielis/hpo-toolkit.svg)](https://github.com/ielis/hpo-toolkit/releases)
 
 A toolkit for working with Human Phenotype Ontology (HPO) and HPO disease annotations in Python.
 
@@ -39,5 +39,5 @@ You got yourself phenotype annotations of 12,468 rare diseases.
 
 Find more info in our detailed documentation:
 
-- [Stable documentation](https://thejacksonlaboratory.github.io/hpo-toolkit/stable) (last release on `main` branch)
-- [Latest documentation](https://thejacksonlaboratory.github.io/hpo-toolkit/latest) (bleeding edge, latest commit on `development` branch)
+- [Stable documentation](https://ielis.github.io/hpo-toolkit/stable) (last release on `main` branch)
+- [Latest documentation](https://ielis.github.io/hpo-toolkit/latest) (bleeding edge, latest commit on `development` branch)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,5 +28,5 @@ Feedback
 --------
 
 The best place to leave feedback, ask questions, and report bugs is the
-`HPO Toolkit's Issue Tracker <https://github.com/TheJacksonLaboratory/hpo-toolkit/issues>`_.
+`HPO Toolkit's Issue Tracker <https://github.com/ielis/hpo-toolkit/issues>`_.
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -20,7 +20,7 @@ The bleeding edge code
 
 To access the bleeding edge features, the development version can be installed by::
 
-  git clone https://github.com/TheJacksonLaboratory/hpo-toolkit.git
+  git clone https://github.com/ielis/hpo-toolkit.git
   cd hpo-toolkit
   git checkout development && git pull
   python3 -m pip install .
@@ -49,7 +49,7 @@ Run benches
 Bench suites provide an idea about the performance of the library.
 Running a bench requires checking out the GitHub repository and installing HPO toolkit with `bench` dependencies::
 
-  git clone https://github.com/TheJacksonLaboratory/hpo-toolkit.git
+  git clone https://github.com/ielis/hpo-toolkit.git
   cd hpo-toolkit
   python3 -m pip install .[bench]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ bench = [
 ]
 
 [project.urls]
-"Repository" = "https://github.com/TheJacksonLaboratory/hpo-toolkit"
+homepage = "https://github.com/ielis/hpo-toolkit"
+repository = "https://github.com/ielis/hpo-toolkit.git"
+documentation = "https://ielis.github.io/hpo-toolkit/stable"
+bugtracker = "https://github.com/ielis/hpo-toolkit/issues"
 
 [tool.setuptools]
 package-dir = { "" = "src" }


### PR DESCRIPTION
Update all URLs to point to the new `hpo-toolkit` location.