### PR TITLE
Prevent storing ontology file at path with `None` in name

### DIFF
--- a/src/hpotk/store/__init__.py
+++ b/src/hpotk/store/__init__.py
@@ -13,12 +13,12 @@ The store can then be used to fetch an ontology with a given release, e.g. `v202
 '2023-10-09'
 """
 
-from ._api import OntologyType, OntologyStore, RemoteOntologyService
-from ._github import GitHubRemoteOntologyService
+from ._api import OntologyType, OntologyStore, RemoteOntologyService, OntologyReleaseService
+from ._github import GitHubRemoteOntologyService, GitHubOntologyReleaseService
 from ._config import configure_ontology_store
 
 __all__ = [
     'configure_ontology_store',
-    'OntologyType', 'OntologyStore', 'RemoteOntologyService',
-    'GitHubRemoteOntologyService',
+    'OntologyType', 'OntologyStore', 'RemoteOntologyService', 'OntologyReleaseService',
+    'GitHubRemoteOntologyService', 'GitHubOntologyReleaseService',
 ]

--- a/src/hpotk/store/_config.py
+++ b/src/hpotk/store/_config.py
@@ -4,12 +4,13 @@ import re
 import typing
 from pathlib import Path
 
-from ._api import OntologyStore, RemoteOntologyService
-from ._github import GitHubRemoteOntologyService
+from ._api import OntologyStore, RemoteOntologyService, OntologyReleaseService
+from ._github import GitHubRemoteOntologyService, GitHubOntologyReleaseService
 
 
 def configure_ontology_store(
         store_dir: typing.Optional[str] = None,
+        ontology_release_service: OntologyReleaseService = GitHubOntologyReleaseService(),
         remote_ontology_service: RemoteOntologyService = GitHubRemoteOntologyService(),
 ) -> OntologyStore:
     """
@@ -17,6 +18,7 @@ def configure_ontology_store(
 
     :param store_dir: a `str` pointing to an existing directory for caching the ontology files
       or `None` if the platform-specific default folder should be used.
+    :param ontology_release_service: an :class:`OntologyReleaseService` for fetching the ontology releases.
     :param remote_ontology_service: a :class:`RemoteOntologyService` responsible for fetching
       the ontology data from a remote location if we do not have the data locally.
     :returns: an :class:`OntologyStore`.
@@ -29,6 +31,7 @@ def configure_ontology_store(
             raise ValueError(f'`store_dir` must point to an existing directory')
     return OntologyStore(
         store_dir=store_dir,
+        ontology_release_service=ontology_release_service,
         remote_ontology_service=remote_ontology_service,
     )
 

--- a/src/hpotk/store/_github.py
+++ b/src/hpotk/store/_github.py
@@ -7,7 +7,70 @@ from urllib.request import urlopen
 
 import certifi
 
-from ._api import OntologyType, RemoteOntologyService
+from ._api import OntologyType, OntologyReleaseService, RemoteOntologyService
+
+
+ONTOLOGY_CREDENTIALS = {
+        OntologyType.HPO: {
+            'owner': 'obophenotype',
+            'repo': 'human-phenotype-ontology',
+        }
+    }
+"""
+The default ontology credentials that only include HPO at the time.
+"""
+
+
+class GitHubOntologyReleaseService(OntologyReleaseService):
+    """
+    `GitHubOntologyReleaseService` can fetch the ontology tags from GitHub.
+    """
+
+    def __init__(
+            self,
+            timeout: int = 10,
+            ontology_credentials: typing.Mapping[OntologyType, typing.Mapping[str, str]] = ONTOLOGY_CREDENTIALS,
+    ):
+        self._logger = logging.getLogger(__name__)
+        self._timeout = timeout
+        self._tag_api_url = 'https://api.github.com/repos/{owner}/{repo}/tags'
+        self._ctx = ssl.create_default_context(cafile=certifi.where())
+        self._ontology_credentials = ontology_credentials
+
+    def fetch_tags(self, ontology_type: OntologyType) -> typing.Iterable[str]:
+        if ontology_type not in self._ontology_credentials:
+            raise ValueError(
+                f'Ontology {ontology_type} not among '
+                f'the known ontology credentials {set(self._ontology_credentials.keys())}'
+            )
+        credentials = self._ontology_credentials[ontology_type]
+
+        return self._get_tag_names(
+            owner=credentials['owner'],
+            repo=credentials['repo'],
+        )
+
+    def _get_tag_names(
+            self,
+            owner: str,
+            repo: str,
+    ) -> typing.Iterable[str]:
+        tag_url = self._tag_api_url.format(owner=owner, repo=repo)
+        self._logger.debug('Pulling tag from %s', tag_url)
+
+        with urlopen(
+                tag_url,
+                timeout=self._timeout,
+                context=self._ctx,
+        ) as fh:
+            tags = json.load(fh)
+
+        if len(tags) == 0:
+            raise ValueError('No tags could be fetched from GitHub tag API')
+        else:
+            self._logger.debug('Fetched %d tags', len(tags))
+
+        return (tag['name'] for tag in tags)
 
 
 class GitHubRemoteOntologyService(RemoteOntologyService):
@@ -17,35 +80,26 @@ class GitHubRemoteOntologyService(RemoteOntologyService):
     The Obographs JSON files are fetched and only HPO is supported as of now.
     """
 
-    ONTOLOGY_CREDENTIALS = {
-        OntologyType.HPO: {
-            'owner': 'obophenotype',
-            'repo': 'human-phenotype-ontology',
-        }
-    }
-
     def __init__(
             self,
             timeout: int = 10,
+            ontology_credentials: typing.Mapping[OntologyType, typing.Mapping[str, str]] = ONTOLOGY_CREDENTIALS,
     ):
         self._logger = logging.getLogger(__name__)
         self._timeout = timeout
         self._ctx = ssl.create_default_context(cafile=certifi.where())
-        self._tag_api_url = 'https://api.github.com/repos/{owner}/{repo}/tags'
         self._release_url = 'https://github.com/{owner}/{repo}/releases/download/{release}/{ontology_id}.json'
+        self._ontology_credentials = ontology_credentials
 
     def fetch_ontology(
             self,
             ontology_type: OntologyType,
-            release: typing.Optional[str] = None,
+            release: str,
     ) -> io.BufferedIOBase:
-        if ontology_type not in self.ONTOLOGY_CREDENTIALS:
+        if ontology_type not in self._ontology_credentials:
             raise ValueError(f'Ontology {ontology_type} not among the known ontology credentials')
-        credentials = self.ONTOLOGY_CREDENTIALS[ontology_type]
+        credentials = self._ontology_credentials[ontology_type]
 
-        # Figure out the desired release
-        if release is None:
-            release = self._fetch_latest_tag_from_github(credentials)
         self._logger.debug('Using %s as the ontology release', release)
 
         owner = credentials['owner']
@@ -63,30 +117,3 @@ class GitHubRemoteOntologyService(RemoteOntologyService):
             timeout=self._timeout,
             context=self._ctx,
         )
-
-    def _fetch_latest_tag_from_github(self, credentials: typing.Mapping[str, str]):
-        self._logger.debug('Release unset, getting the latest')
-        tag_names = self._get_tag_names(
-            owner=credentials['owner'],
-            repo=credentials['repo'],
-        )
-        # We assume lexicographic sorting of the tags
-        return max(tag_names)
-
-    def _get_tag_names(self, owner: str, repo: str) -> typing.Iterable[str]:
-        tag_url = self._tag_api_url.format(owner=owner, repo=repo)
-        self._logger.debug('Pulling tag from %s', tag_url)
-
-        with urlopen(
-                tag_url,
-                timeout=self._timeout,
-                context=self._ctx,
-        ) as fh:
-            tags = json.load(fh)
-
-        if len(tags) == 0:
-            raise ValueError('No tags could be fetched from GitHub tag API')
-        else:
-            self._logger.debug('Fetched %d tags', len(tags))
-
-        return (tag['name'] for tag in tags)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,33 @@
 import os
 
 import pytest
+
 import hpotk
+
+
+# ####################################### Pytest options ############################################################# #
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runonline", action="store_true", default=False, help="run online tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "online: mark test that require internet access to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runonline"):
+        # --runonline given in cli: do not skip online tests
+        return
+    skip_online = pytest.mark.skip(reason="need --runonline option to run")
+    for item in items:
+        if "online" in item.keywords:
+            item.add_marker(skip_online)
+
+
+# ####################################### Fixtures ################################################################### #
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -80,3 +80,30 @@ class TestGitHubOntologyStore:
 
         # We test that we get whatever exception was raised by the `RemoteOntologyService`.
         assert e.value.args[0] == f'Unsupported release {release}'
+
+
+@pytest.mark.online
+class TestGitHubOntologyReleaseService:
+
+    @pytest.fixture
+    def ontology_release_service(self) -> hpotk.store.OntologyReleaseService:
+        return hpotk.store.GitHubOntologyReleaseService()
+
+    def test_ontology_release_service(
+            self,
+            ontology_release_service: hpotk.store.OntologyReleaseService,
+    ):
+        tag_iter = ontology_release_service.fetch_tags(hpotk.store.OntologyType.HPO)
+
+        assert tag_iter is not None
+
+        tags = set(tag_iter)
+
+        expected = {  # As of May 20th, 2024
+            'v2020-08-11', 'v2020-10-12', 'v2020-12-07', 'v2021-02-08', 'v2021-04-13', 'v2021-06-08', 'v2021-06-13',
+            'v2021-08-02', 'v2021-10-10', 'v2022-01-27', 'v2022-02-14', 'v2022-04-14', 'v2022-06-11', 'v2022-10-05',
+            'v2022-12-15', 'v2023-01-27', 'v2023-04-05', 'v2023-06-06', 'v2023-06-17', 'v2023-07-21', 'v2023-09-01',
+            'v2023-10-09', 'v2024-01-11', 'v2024-01-16', 'v2024-02-08', 'v2024-03-06', 'v2024-04-03', 'v2024-04-04',
+            'v2024-04-19', 'v2024-04-26',
+        }
+        assert all(tag in tags for tag in expected)


### PR DESCRIPTION
Fix `OntologyStore` bug where an ontology name can be constructed from `None` if release is not set.