### PR TITLE
Expose `OntologyStore` resource path and enable resource cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .idea/
 *.iml
 
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docs/user-guide/load-ontology.rst
+++ b/docs/user-guide/load-ontology.rst
@@ -66,12 +66,26 @@ Moreover, `OntologyStore` will load the *latest* release, if the `release` optio
 
 .. doctest:: load-minimal-ontology
 
-  >>> hpo_latest = store.load_minimal_hpo()  # doctest: +SKIP
+  >>> hpo_latest = store.load_minimal_hpo()
   >>> hpo_latest.version  # doctest: +SKIP
   '2024-03-06'
 
 As of the time of this writing, ``2024-03-06`` is the latest HPO release.
 
+
+The store exposes the path of the ontology resources. For HPO, this is the path to the JSON file:
+
+.. doctest:: load-minimal-ontology
+
+  >>> fpath_hpo = store.resolve_store_path(ontology_type=hpotk.OntologyType.HPO, release='v2023-10-09')
+  >>> fpath_hpo  # doctest: +SKIP
+  '/path/to/.hpo-toolkit/HP/hp.v2023-10-09.json'
+
+The ontology resources can be cleaned to remove the content of the local directory:
+
+.. doctest:: load-minimal-ontology
+
+  >>> store.clear()  # doctest: +SKIP
 
 Next steps
 **********

--- a/src/hpotk/store/__init__.py
+++ b/src/hpotk/store/__init__.py
@@ -11,6 +11,16 @@ The store can then be used to fetch an ontology with a given release, e.g. `v202
 >>> hpo = store.load_minimal_hpo(release='v2023-10-09')
 >>> hpo.version
 '2023-10-09'
+
+or fetch the *latest* release by omitting the `release` argument:
+
+>>> latest_hpo = store.load_minimal_hpo()
+>>> latest_hpo.version  # doctest: +SKIP
+'2024-04-26'
+
+.. note::
+
+  The release `2024-04-26` is the latest release as of June 2024 when this documentation was written.
 """
 
 from ._api import OntologyType, OntologyStore, RemoteOntologyService, OntologyReleaseService

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -81,6 +81,25 @@ class TestGitHubOntologyStore:
         # We test that we get whatever exception was raised by the `RemoteOntologyService`.
         assert e.value.args[0] == f'Unsupported release {release}'
 
+    @pytest.mark.parametrize(
+            'ontology_type,release,expected_fname',
+            [
+                (hpotk.store.OntologyType.HPO, 'v2024-04-19', 'hp.v2024-04-19.json'),
+                (hpotk.store.OntologyType.HPO, 'v2024-04-26', 'hp.v2024-04-26.json'),
+            ]
+    )
+    def test_resolve_store_path(
+            self,
+            ontology_store: hpotk.OntologyStore,
+            ontology_type: hpotk.store.OntologyType,
+            release: str,
+            expected_fname: str,
+    ):
+        actual = ontology_store.resolve_store_path(ontology_type=ontology_type, release=release)
+        
+        expected = os.path.join(ontology_store.store_dir, ontology_type.identifier, expected_fname)
+        assert actual == expected
+
 
 @pytest.mark.online
 class TestGitHubOntologyReleaseService:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -11,95 +11,163 @@ import hpotk
 class MockRemoteOntologyService(hpotk.store.RemoteOntologyService):
 
     def __init__(
-            self,
-            release: str,
-            payload: bytes,
+        self,
+        release: str,
+        payload: bytes,
     ):
         self._release = release
         self._payload = payload
 
     def fetch_ontology(
-            self,
-            ontology_type: hpotk.OntologyType,
-            release: typing.Optional[str] = None,
+        self,
+        ontology_type: hpotk.OntologyType,
+        release: typing.Optional[str] = None,
     ) -> io.BufferedIOBase:
         if release == self._release:
             return io.BytesIO(self._payload)
         else:
-            raise ValueError(f'Unsupported release {release}')
+            raise ValueError(f"Unsupported release {release}")
 
 
 class TestGitHubOntologyStore:
 
-    @pytest.fixture(scope='class')
+    @pytest.fixture(scope="class")
     def remote_ontology_service(
-            self,
-            fpath_toy_hpo: str,
+        self,
+        fpath_toy_hpo: str,
     ) -> hpotk.store.RemoteOntologyService:
-        with open(fpath_toy_hpo, 'rb') as fh:
+        with open(fpath_toy_hpo, "rb") as fh:
             return MockRemoteOntologyService(
-                release='v2022-10-05',
+                release="v2022-10-05",
                 payload=fh.read(),
             )
 
     @pytest.fixture
     def ontology_store(
-            self,
-            tmp_path: Path,
-            remote_ontology_service: hpotk.store.RemoteOntologyService,
+        self,
+        tmp_path: Path,
+        remote_ontology_service: hpotk.store.RemoteOntologyService,
     ) -> hpotk.OntologyStore:
-        return hpotk.configure_ontology_store(
+        ontology_release_service = hpotk.store.GitHubOntologyReleaseService()
+        return hpotk.store.OntologyStore(
             store_dir=str(tmp_path),
+            ontology_release_service=ontology_release_service,
             remote_ontology_service=remote_ontology_service,
         )
 
     def test_load_minimal_hpo(
-            self,
-            ontology_store: hpotk.OntologyStore,
+        self,
+        ontology_store: hpotk.OntologyStore,
     ):
         # We start with a clean slate.
         assert len(os.listdir(ontology_store.store_dir)) == 0
 
-        release = 'v2022-10-05'
+        release = "v2022-10-05"
         hpo = ontology_store.load_minimal_hpo(release=release)
 
         assert isinstance(hpo, hpotk.MinimalOntology)
         assert hpo.version == release[1:]
 
-        fpath_expected = os.path.join(ontology_store.store_dir, 'HP', f'hp.{release}.json')
+        fpath_expected = os.path.join(
+            ontology_store.store_dir, "HP", f"hp.{release}.json"
+        )
         assert os.path.isfile(fpath_expected)
 
     def test_load_minimal_hpo__invalid_release(
-            self,
-            ontology_store: hpotk.OntologyStore,
+        self,
+        ontology_store: hpotk.OntologyStore,
     ):
 
-        release = 'v3400-12-31'
+        release = "v3400-12-31"
         with pytest.raises(ValueError) as e:
             ontology_store.load_minimal_hpo(release=release)
 
         # We test that we get whatever exception was raised by the `RemoteOntologyService`.
-        assert e.value.args[0] == f'Unsupported release {release}'
+        assert e.value.args[0] == f"Unsupported release {release}"
 
     @pytest.mark.parametrize(
-            'ontology_type,release,expected_fname',
-            [
-                (hpotk.store.OntologyType.HPO, 'v2024-04-19', 'hp.v2024-04-19.json'),
-                (hpotk.store.OntologyType.HPO, 'v2024-04-26', 'hp.v2024-04-26.json'),
-            ]
+        "ontology_type,release,expected_fname",
+        [
+            (hpotk.store.OntologyType.HPO, "v2024-04-19", "hp.v2024-04-19.json"),
+            (hpotk.store.OntologyType.HPO, "v2024-04-26", "hp.v2024-04-26.json"),
+        ],
     )
     def test_resolve_store_path(
-            self,
-            ontology_store: hpotk.OntologyStore,
-            ontology_type: hpotk.store.OntologyType,
-            release: str,
-            expected_fname: str,
+        self,
+        ontology_store: hpotk.OntologyStore,
+        ontology_type: hpotk.store.OntologyType,
+        release: str,
+        expected_fname: str,
     ):
-        actual = ontology_store.resolve_store_path(ontology_type=ontology_type, release=release)
-        
-        expected = os.path.join(ontology_store.store_dir, ontology_type.identifier, expected_fname)
+        actual = ontology_store.resolve_store_path(
+            ontology_type=ontology_type, release=release
+        )
+
+        expected = os.path.join(
+            ontology_store.store_dir, ontology_type.identifier, expected_fname
+        )
         assert actual == expected
 
+    def test_clear__everything(
+        self,
+        ontology_store: hpotk.OntologyStore,
+    ):
+        store_dir = Path(ontology_store.store_dir)
+        
+        stuff = os.listdir(store_dir)
+        assert len(stuff) == 0, "The store directory is empty upon start"
+        
+        TestGitHubOntologyStore.initialize_store_dir(store_dir)
+
+        stuff = os.listdir(store_dir)
+        assert len(stuff) == 3, 'The store directory now includes two folders and one file'
+
+        ontology_store.clear()
+
+        stuff = os.listdir(store_dir)
+        assert len(stuff) == 0, "The store directory is empty after clearing everything"
+
+    @pytest.mark.parametrize(
+        'resource',
+        [
+            hpotk.OntologyType.HPO,
+        ],
+    )
+    def test_clear__ontology_type(
+        self,
+        resource: hpotk.OntologyType,
+        ontology_store: hpotk.OntologyStore,
+    ):
+        store_dir = Path(ontology_store.store_dir)
+        stuff = os.listdir(store_dir)
+
+        assert len(stuff) == 0, "The store directory is empty upon start"
+
+        TestGitHubOntologyStore.initialize_store_dir(store_dir)
+
+        stuff = os.listdir(store_dir)
+        assert len(stuff) == 3, 'The store directory now includes two folders and one file'
+
+        ontology_store.clear(resource)
+
+        stuff = os.listdir(store_dir)
+        assert len(stuff) == 2
+
+
+    @staticmethod
+    def initialize_store_dir(store_dir: Path):
+        # Make a few folders and files
+        store_dir.joinpath('joe.txt').touch()  # a file
+        
+        hp_path = store_dir.joinpath('HP')  # a folder
+        os.mkdir(hp_path)
+        hp_path.joinpath('a.txt').touch()
+        hp_path.joinpath('b.txt').touch()
+
+        mondo_path = store_dir.joinpath('MONDO')  # another folder
+        os.mkdir(mondo_path)
+        mondo_path.joinpath('x.txt').touch()
+        mondo_path.joinpath('y.txt').touch()
 
 @pytest.mark.online
 class TestGitHubOntologyReleaseService:
@@ -109,8 +177,8 @@ class TestGitHubOntologyReleaseService:
         return hpotk.store.GitHubOntologyReleaseService()
 
     def test_ontology_release_service(
-            self,
-            ontology_release_service: hpotk.store.OntologyReleaseService,
+        self,
+        ontology_release_service: hpotk.store.OntologyReleaseService,
     ):
         tag_iter = ontology_release_service.fetch_tags(hpotk.store.OntologyType.HPO)
 
@@ -119,10 +187,35 @@ class TestGitHubOntologyReleaseService:
         tags = set(tag_iter)
 
         expected = {  # As of May 20th, 2024
-            'v2020-08-11', 'v2020-10-12', 'v2020-12-07', 'v2021-02-08', 'v2021-04-13', 'v2021-06-08', 'v2021-06-13',
-            'v2021-08-02', 'v2021-10-10', 'v2022-01-27', 'v2022-02-14', 'v2022-04-14', 'v2022-06-11', 'v2022-10-05',
-            'v2022-12-15', 'v2023-01-27', 'v2023-04-05', 'v2023-06-06', 'v2023-06-17', 'v2023-07-21', 'v2023-09-01',
-            'v2023-10-09', 'v2024-01-11', 'v2024-01-16', 'v2024-02-08', 'v2024-03-06', 'v2024-04-03', 'v2024-04-04',
-            'v2024-04-19', 'v2024-04-26',
+            "v2020-08-11",
+            "v2020-10-12",
+            "v2020-12-07",
+            "v2021-02-08",
+            "v2021-04-13",
+            "v2021-06-08",
+            "v2021-06-13",
+            "v2021-08-02",
+            "v2021-10-10",
+            "v2022-01-27",
+            "v2022-02-14",
+            "v2022-04-14",
+            "v2022-06-11",
+            "v2022-10-05",
+            "v2022-12-15",
+            "v2023-01-27",
+            "v2023-04-05",
+            "v2023-06-06",
+            "v2023-06-17",
+            "v2023-07-21",
+            "v2023-09-01",
+            "v2023-10-09",
+            "v2024-01-11",
+            "v2024-01-16",
+            "v2024-02-08",
+            "v2024-03-06",
+            "v2024-04-03",
+            "v2024-04-04",
+            "v2024-04-19",
+            "v2024-04-26",
         }
         assert all(tag in tags for tag in expected)


### PR DESCRIPTION
Expose paths of ontology resources managed by the `OntologyStore`.