### PR TITLE
Test `TermId` hashing, add editor config and linter config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*]
+max_line_length = 120
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,15 @@
+[flake8]
+max-line-length = 120
+
+# F405 - ignore error if class is imported in `*` import.
+# W293 - blank line contains whitespace
+# W503 - line break before binary operator
+ignore = F405,W293,W503
+
+exclude =
+    .git,
+    __pycache__,
+    docs/conf.py,
+    build,
+    dist,
+    venv,

--- a/src/hpotk/__init__.py
+++ b/src/hpotk/__init__.py
@@ -2,17 +2,7 @@
 HPO toolkit is a library for working with Human Phenotype Ontology and the HPO annotation data.
 """
 
-__version__ = '0.5.3.dev0'
-
-from . import algorithm
-from . import annotations
-from . import constants
-from . import graph
-from . import model
-from . import ontology
-from . import store
-from . import util
-from . import validate
+__version__ = "0.5.3.dev0"
 
 from .graph import OntologyGraph, GraphAware
 from .model import TermId, Term, MinimalTerm, Synonym, SynonymType, SynonymCategory
@@ -20,3 +10,10 @@ from .ontology import Ontology, MinimalOntology
 
 from .ontology.load.obographs import load_minimal_ontology, load_ontology
 from .store import OntologyType, OntologyStore, configure_ontology_store
+
+__all__ = [
+    "TermId", "MinimalTerm", "Term",
+    "OntologyGraph", "GraphAware",
+    "MinimalOntology", "Ontology",
+    "OntologyStore", "OntologyType", "configure_ontology_store",
+]

--- a/src/hpotk/ontology/load/obographs/_load.py
+++ b/src/hpotk/ontology/load/obographs/_load.py
@@ -15,10 +15,11 @@ from ._factory import MinimalTermFactory, TermFactory, ObographsTermFactory, MIN
 
 logger = logging.getLogger(__name__)
 
-# TODO - verify PURL works for other ontologies than HPO
+# TODO: verify PURL works for other ontologies than HPO
+# TODO: thoroughly test the PURL pattern
 # A pattern to match an obolibrary PURL. The PURL should is expected to have 3 parts: `prefix`, `id`, and `curie`
 # The `curie` is `prefix` + '_' + `id`.
-PURL_PATTERN = re.compile(r'http://purl\.obolibrary\.org/obo/(?P<curie>(?P<prefix>\w+)_(?P<id>\d{7}))')
+PURL_PATTERN = re.compile(r'http://purl\.obolibrary\.org/obo/(?P<curie>(?P<prefix>\w+)_(?P<id>\w+))')
 DATE_PATTERN = re.compile(r'.*/(?P<date>\d{4}-\d{2}-\d{2})/.*')
 
 

--- a/tests/test_term_id.py
+++ b/tests/test_term_id.py
@@ -52,6 +52,20 @@ class TestTermId:
 
         assert left == right
 
+    @pytest.mark.parametrize(
+        'left, right',
+        (
+            ["HP:1234567", "HP:1234567"],
+            ["HP:1234567", "HP_1234567"],
+            ["HP_1234567", "HP:1234567"],
+            ["HP_1234567", "HP_1234567"],
+        ))
+    def test_hash(self, left: str, right: str):
+        left = TermId.from_curie(left)
+        right = TermId.from_curie(right)
+
+        assert hash(left) == hash(right)
+
     @pytest.mark.parametrize('left, right, is_gt, is_eq, is_lt',
                              (
                                      # First compare by prefix

--- a/tests/test_term_id.py
+++ b/tests/test_term_id.py
@@ -1,13 +1,16 @@
 import pytest
 
-from hpotk.model import *
+from hpotk.model import TermId
 
 
 class TestTermId:
 
-    @pytest.mark.parametrize('curie',
-                             ("HP:1234567", "HP_1234567")
-                             )
+    @pytest.mark.parametrize(
+        'curie',
+        (
+            "HP:1234567", 
+            "HP_1234567",
+        ))
     def test_from_curie(self, curie):
         term_id = TermId.from_curie(curie)
         assert term_id.value == "HP:1234567"
@@ -17,22 +20,26 @@ class TestTermId:
         assert term_id.prefix == 'SNOMEDCT_US'
         assert term_id.id == '313307000'
 
-    @pytest.mark.parametrize('curie, message',
-                             (("HP1234567", "The CURIE HP1234567 has no colon `:` or underscore `_`"),
-                              (None, "Curie must not be None"))
-                             )
+    @pytest.mark.parametrize(
+        'curie, message',
+        [
+            ("HP1234567", "The CURIE HP1234567 has no colon `:` or underscore `_`"),
+            (None, "Curie must not be None")
+        ]
+    )
     def test_from_curie__failures(self, curie, message):
         with pytest.raises(ValueError) as cm:
             TermId.from_curie(curie)
 
         assert message == cm.value.args[0]
 
-    @pytest.mark.parametrize('curie, prefix, id',
-                             (
-                                     ["HP:1234567", "HP", "1234567"],
-                                     ["HP_1234567", "HP", "1234567"]
-                             )
-                             )
+    @pytest.mark.parametrize(
+        'curie, prefix, id',
+        (
+            ["HP:1234567", "HP", "1234567"],
+            ["HP_1234567", "HP", "1234567"]
+        )
+    )
     def test_properties(self, curie, prefix, id):
         term_id = TermId.from_curie(curie)
 
@@ -40,12 +47,15 @@ class TestTermId:
         assert id == term_id.id
         assert f'{prefix}:{id}' == term_id.value
 
-    @pytest.mark.parametrize('left, right',
-                             (["HP:1234567", "HP:1234567"],
-                              ["HP:1234567", "HP_1234567"],
-                              ["HP_1234567", "HP:1234567"],
-                              ["HP_1234567", "HP_1234567"],)
-                             )
+    @pytest.mark.parametrize(
+        'left, right',
+        (
+            ["HP:1234567", "HP:1234567"],
+            ["HP:1234567", "HP_1234567"],
+            ["HP_1234567", "HP:1234567"],
+            ["HP_1234567", "HP_1234567"],
+        )
+    )
     def test_equality(self, left, right):
         left = TermId.from_curie(left)
         right = TermId.from_curie(right)
@@ -66,18 +76,19 @@ class TestTermId:
 
         assert hash(left) == hash(right)
 
-    @pytest.mark.parametrize('left, right, is_gt, is_eq, is_lt',
-                             (
-                                     # First compare by prefix
-                                     ["AA:0000000", "BB:0000000", False, False, True],
-                                     ["BB:0000000", "BB:0000000", False, True, False],
-                                     ["CC:0000000", "BB:0000000", True, False, False],
-                                     # Then by value
-                                     ["HP:0000001", "HP:0000002", False, False, True],
-                                     ["HP:0000002", "HP:0000002", False, True, False],
-                                     ["HP:0000003", "HP:0000002", True, False, False],
-                             )
-                             )
+    @pytest.mark.parametrize(
+        'left, right, is_gt, is_eq, is_lt',
+        (
+            # First compare by prefix
+            ["AA:0000000", "BB:0000000", False, False, True],
+            ["BB:0000000", "BB:0000000", False, True, False],
+            ["CC:0000000", "BB:0000000", True, False, False],
+            # Then by value
+            ["HP:0000001", "HP:0000002", False, False, True],
+            ["HP:0000002", "HP:0000002", False, True, False],
+            ["HP:0000003", "HP:0000002", True, False, False],
+        )
+    )
     def test_comparison(self, left, right, is_gt, is_eq, is_lt):
         left = TermId.from_curie(left)
         right = TermId.from_curie(right)


### PR DESCRIPTION
Test that different `TermId` formats hash properly.

Reformat parametrized tests to improve readability.