### PR TITLE
Reexport ontology loaders

### DIFF
--- a/src/hpotk/__init__.py
+++ b/src/hpotk/__init__.py
@@ -16,4 +16,5 @@ __all__ = [
     "OntologyGraph", "GraphAware",
     "MinimalOntology", "Ontology",
     "OntologyStore", "OntologyType", "configure_ontology_store",
+    "load_minimal_ontology", "load_ontology",
 ]


### PR DESCRIPTION
The ontology loaders should stay in the top-level package.