### PR TITLE
Improve ontology release tag handling

### DIFF
--- a/src/hpotk/store/_api.py
+++ b/src/hpotk/store/_api.py
@@ -82,8 +82,8 @@ class OntologyReleaseService(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def fetch_tags(
-            self,
-            ontology_type: OntologyType,
+        self,
+        ontology_type: OntologyType,
     ) -> typing.Iterable[str]:
         """
         Fetch sequence of tags for an ontology.
@@ -100,10 +100,10 @@ class OntologyStore:
     """
 
     def __init__(
-            self,
-            store_dir: str,
-            ontology_release_service: OntologyReleaseService,
-            remote_ontology_service: RemoteOntologyService,
+        self,
+        store_dir: str,
+        ontology_release_service: OntologyReleaseService,
+        remote_ontology_service: RemoteOntologyService,
     ):
         self._logger = logging.getLogger(__name__)
         self._store_dir = store_dir

--- a/src/hpotk/store/_config.py
+++ b/src/hpotk/store/_config.py
@@ -9,9 +9,9 @@ from ._github import GitHubRemoteOntologyService, GitHubOntologyReleaseService
 
 
 def configure_ontology_store(
-        store_dir: typing.Optional[str] = None,
-        ontology_release_service: OntologyReleaseService = GitHubOntologyReleaseService(),
-        remote_ontology_service: RemoteOntologyService = GitHubRemoteOntologyService(),
+    store_dir: typing.Optional[str] = None,
+    ontology_release_service: OntologyReleaseService = GitHubOntologyReleaseService(),
+    remote_ontology_service: RemoteOntologyService = GitHubRemoteOntologyService(),
 ) -> OntologyStore:
     """
     Configure and create the default ontology store.
@@ -28,7 +28,7 @@ def configure_ontology_store(
         store_dir = get_default_ontology_store_dir()
     else:
         if not os.path.isdir(store_dir):
-            raise ValueError(f'`store_dir` must point to an existing directory')
+            raise ValueError('`store_dir` must point to an existing directory')
     return OntologyStore(
         store_dir=store_dir,
         ontology_release_service=ontology_release_service,

--- a/src/hpotk/store/_github.py
+++ b/src/hpotk/store/_github.py
@@ -11,27 +11,31 @@ import certifi
 from ._api import OntologyType, OntologyReleaseService, RemoteOntologyService
 
 
+production_tag_pt = r'^v(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$'
+"""
+A tag pattern to ensure we only include the "production" tags (e.g. not `v2024-12-12X`).
+"""
+
+
 ONTOLOGY_CREDENTIALS = {
         OntologyType.HPO: {
             'owner': 'obophenotype',
             'repo': 'human-phenotype-ontology',
-            'tag_pt': r'^v(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$',
+            'tag_pt': production_tag_pt,
         },
         OntologyType.MAxO: {
             'owner': 'monarch-initiative',
             'repo': 'MAxO',
-            'tag_pt': r'^v(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$',
+            'tag_pt': production_tag_pt,
         },
         OntologyType.MONDO: {
             'owner': 'monarch-initiative',
             'repo': 'mondo',
-            'tag_pt': r'^v(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})$',
+            'tag_pt': production_tag_pt,
         },
     }
 """
 The default ontology credentials that only include HPO, MAxO, and MONDO at this time.
-
-The tag pattern ensures we only include the "production" tags (e.g. not `2024-12-12X`).
 """
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -173,6 +173,15 @@ class TestGitHubOntologyStoreOffline:
         mondo_path.joinpath("x.txt").touch()
         mondo_path.joinpath("y.txt").touch()
 
+    @pytest.mark.skip("Just for manual debugging")
+    def test_resolve_store_path__latest(
+        self,
+        ontology_store: hpotk.OntologyStore,
+    ):
+        latest = ontology_store.resolve_store_path(hpotk.store.OntologyType.HPO)
+        print(latest)
+
+
 @pytest.mark.online
 class TestGitHubOntologyStoreOnline:
     """


### PR DESCRIPTION
Only include the ontology release tags that match `^v\d{4}-\d{2}-\d{2}$` pattern.