### PR TITLE
Add hierarchy queries that include the source

### DIFF
--- a/src/hpotk/constants/__init__.py
+++ b/src/hpotk/constants/__init__.py
@@ -3,3 +3,7 @@ A module with useful constants of the supported ontologies.
 """
 
 from . import hpo
+
+__all__ = [
+    "hpo",
+]

--- a/src/hpotk/constants/__init__.py
+++ b/src/hpotk/constants/__init__.py
@@ -1,9 +1,3 @@
 """
 A module with useful constants of the supported ontologies.
 """
-
-from . import hpo
-
-__all__ = [
-    "hpo",
-]

--- a/src/hpotk/constants/hpo/__init__.py
+++ b/src/hpotk/constants/hpo/__init__.py
@@ -1,19 +1,3 @@
 """
 A module with commonly used HPO constants.
 """
-
-from . import base
-from . import frequency
-from . import inheritance
-from . import onset
-from . import organ_system
-from . import severity
-
-__all__ = [
-    "base",
-    "frequency",
-    "inheritance",
-    "onset",
-    "organ_system",
-    "severity",
-]

--- a/src/hpotk/constants/hpo/__init__.py
+++ b/src/hpotk/constants/hpo/__init__.py
@@ -8,3 +8,12 @@ from . import inheritance
 from . import onset
 from . import organ_system
 from . import severity
+
+__all__ = [
+    "base",
+    "frequency",
+    "inheritance",
+    "onset",
+    "organ_system",
+    "severity",
+]

--- a/src/hpotk/constants/hpo/frequency.py
+++ b/src/hpotk/constants/hpo/frequency.py
@@ -75,13 +75,13 @@ def parse_hpo_frequency(value: CURIE_OR_TERM_ID) -> typing.Optional[HpoFrequency
     :return: :class:`HpoFrequency` or `None`.
     """
     if isinstance(value, TermId):
-        pass
+        key = value
     elif isinstance(value, str):
-        value = TermId.from_curie(value)
+        key = TermId.from_curie(value)
     else:
         return None
 
     try:
-        return HPO_FREQUENCIES[value]
+        return HPO_FREQUENCIES[key]
     except KeyError:
         return None

--- a/src/hpotk/graph/_api.py
+++ b/src/hpotk/graph/_api.py
@@ -95,8 +95,11 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
             return False
         return True
 
-    def is_parent_of(self, sub: typing.Union[str, NODE, Identified],
-                     obj: typing.Union[str, NODE, Identified]) -> bool:
+    def is_parent_of(
+        self,
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
         """
         Return `True` if the subject `sub` is a parent of the object `obj`.
 
@@ -105,10 +108,36 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
         :return: `True` if the `sub` is a parent of the `obj`.
         :raises ValueError: if `obj` is not present in the graph.
         """
-        return self._run_query(self.get_parents, sub, obj)
+        return self._run_query(
+            self.get_parents,
+            sub,
+            obj,
+        )
+    
+    def is_parent_of_or_equal_to(
+        self,
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
+        """
+        Return `True` if the subject `sub` is equal to or parent of the object `obj`.
 
-    def is_ancestor_of(self, sub: typing.Union[str, NODE, Identified],
-                       obj: typing.Union[str, NODE, Identified]) -> bool:
+        :param sub: a graph node.
+        :param obj: other graph node.
+        :return: `True` if `sub` is a equal to or parent of `obj`.
+        :raises ValueError: if `obj` is not present in the graph.
+        """
+        return self._test_equal_to_and_maybe_run_query(
+            self.get_parents,
+            sub,
+            obj,
+        )
+
+    def is_ancestor_of(
+        self,
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
         """
         Return `True` if the subject `sub` is an ancestor of the object `obj`.
 
@@ -119,8 +148,30 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
         """
         return self._run_query(self.get_ancestors, sub, obj)
 
-    def is_child_of(self, sub: typing.Union[str, NODE, Identified],
-                    obj: typing.Union[str, NODE, Identified]) -> bool:
+    def is_ancestor_of_or_equal_to(
+        self,
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
+        """
+        Return `True` if the subject `sub` is equal to or ancestor of the object `obj`.
+
+        :param sub: a graph node.
+        :param obj: other graph node.
+        :return: `True` if `sub` is a equal to or ancestor of `obj`.
+        :raises ValueError: if `obj` is not present in the graph.
+        """
+        return self._test_equal_to_and_maybe_run_query(
+            self.get_ancestors,
+            sub,
+            obj,
+        )
+
+    def is_child_of(
+        self,
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
         """
         Return `True` if the `sub` is a child of the `obj`.
 
@@ -130,9 +181,31 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
         :raises ValueError: if `obj` is not present in the graph.
         """
         return self._run_query(self.get_children, sub, obj)
+    
+    def is_child_of_or_equal_to(
+        self,
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
+        """
+        Return `True` if the subject `sub` is equal to or child of the object `obj`.
 
-    def is_descendant_of(self, sub: typing.Union[str, NODE, Identified],
-                         obj: typing.Union[str, NODE, Identified]) -> bool:
+        :param sub: a graph node.
+        :param obj: other graph node.
+        :return: `True` if `sub` is a equal to or child of `obj`.
+        :raises ValueError: if `obj` is not present in the graph.
+        """
+        return self._test_equal_to_and_maybe_run_query(
+            self.get_children,
+            sub,
+            obj,
+        )
+
+    def is_descendant_of(
+        self,
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
         """
         Return `True` if the `sub` is a descendant of the `obj`.
 
@@ -142,13 +215,60 @@ class OntologyGraph(typing.Generic[NODE], metaclass=abc.ABCMeta):
         :raises ValueError: if `obj` is not present in the graph.
         """
         return self._run_query(self.get_descendants, sub, obj)
+    
+    def is_descendant_of_or_equal_to(
+        self,
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
+        """
+        Return `True` if the subject `sub` is equal to or descendant of the object `obj`.
+
+        :param sub: a graph node.
+        :param obj: other graph node.
+        :return: `True` if `sub` is a equal to or descendant of `obj`.
+        :raises ValueError: if `obj` is not present in the graph.
+        """
+        return self._test_equal_to_and_maybe_run_query(
+            self.get_descendants,
+            sub,
+            obj,
+        )
 
     @staticmethod
-    def _run_query(func: typing.Callable[[NODE], typing.Iterator[NODE]],
-                   sub: typing.Union[str, NODE, Identified],
-                   obj: typing.Union[str, NODE, Identified]) -> bool:
-        sub = OntologyGraph._map_to_term_id(sub)
-        obj = OntologyGraph._map_to_term_id(obj)
+    def _run_query(
+        func: typing.Callable[[NODE], typing.Iterator[NODE]],
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
+        sub_ = OntologyGraph._map_to_term_id(sub)
+        obj_ = OntologyGraph._map_to_term_id(obj)
+        return OntologyGraph._exec_query(
+            func,
+            sub_,
+            obj_,
+        )
+    
+    @staticmethod
+    def _test_equal_to_and_maybe_run_query(
+        func: typing.Callable[[NODE], typing.Iterator[NODE]],
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
+        sub_ = OntologyGraph._map_to_term_id(sub)
+        obj_ = OntologyGraph._map_to_term_id(obj)
+        return sub_ == obj_ or OntologyGraph._exec_query(
+            func,
+            sub_,
+            obj_,
+        )
+    
+    @staticmethod
+    def _exec_query(
+        func: typing.Callable[[NODE], typing.Iterator[NODE]],
+        sub: typing.Union[str, NODE, Identified],
+        obj: typing.Union[str, NODE, Identified],
+    ) -> bool:
         return any(sub == term_id for term_id in func(obj))
 
     @abc.abstractmethod

--- a/src/hpotk/graph/_factory.py
+++ b/src/hpotk/graph/_factory.py
@@ -40,7 +40,7 @@ class GraphFactory(typing.Generic[GRAPH], metaclass=abc.ABCMeta):
 
 class AbstractCsrGraphFactory(GraphFactory[OntologyGraph], metaclass=abc.ABCMeta):
 
-    def create_graph(self, edge_list: typing.Sequence[DirectedEdge]) -> GRAPH:
+    def create_graph(self, edge_list: typing.Sequence[DirectedEdge]) -> OntologyGraph:
         # Find root node
         self._logger.debug('Creating ontology graph from %d edges', len(edge_list))
         root, edge_list = _phenol_find_root(edge_list)
@@ -101,7 +101,7 @@ class CsrIndexedGraphFactory(GraphFactory[IndexedOntologyGraph]):
     def __init__(self):
         super().__init__()
 
-    def create_graph(self, edge_list: typing.Sequence[DirectedEdge]) -> GRAPH:
+    def create_graph(self, edge_list: typing.Sequence[DirectedEdge]) -> IndexedOntologyGraph[TermId]:
         # Find root node
         self._logger.debug('Creating ontology graph from %d edges', len(edge_list))
         root, edge_list = _phenol_find_root(edge_list)
@@ -216,7 +216,7 @@ def _phenol_find_root(edge_list: typing.Sequence[DirectedEdge]) -> typing.Tuple[
 
     candidates = root_candidate_set.difference(remove_mark_set)
     if len(candidates) == 0:
-        raise ValueError(f'No root candidate found')
+        raise ValueError('No root candidate found')
     if len(candidates) == 1:
         return candidates.pop(), edge_list
     else:

--- a/src/hpotk/graph/_test__api.py
+++ b/src/hpotk/graph/_test__api.py
@@ -335,6 +335,77 @@ class TestIsLeaf:
         assert base_graph.is_leaf(query) is expected
 
 
+class TestOntologyGraphQueries:
+
+    @pytest.mark.parametrize(
+        'sub, obj, expected',
+        [
+            ('HP:1', 'HP:1', True),
+            ('HP:1', 'HP:01', True),
+            ('HP:1', 'HP:010', False),
+        ]
+    )
+    def test_is_parent_of_or_equal_to(
+        self,
+        base_graph: OntologyGraph,
+        sub: str, obj: str, expected: bool,
+    ):
+        assert base_graph.is_parent_of_or_equal_to(
+            sub, obj,
+        ) is expected
+
+    @pytest.mark.parametrize(
+        'sub, obj, expected',
+        [
+            ('HP:1', 'HP:1', True),
+            ('HP:1', 'HP:01', True),
+            ('HP:1', 'HP:010', True),
+        ]
+    )
+    def test_is_ancestor_of_or_equal_to(
+        self,
+        base_graph: OntologyGraph,
+        sub: str, obj: str, expected: bool,
+    ):
+        assert base_graph.is_ancestor_of_or_equal_to(
+            sub, obj,
+        ) is expected
+
+    @pytest.mark.parametrize(
+        'sub, obj, expected',
+        [
+            ('HP:1', 'HP:1', True),
+            ('HP:01', 'HP:1', True),
+            ('HP:010', 'HP:1', False),
+        ]
+    )
+    def test_is_child_of_or_equal_to(
+        self,
+        base_graph: OntologyGraph,
+        sub: str, obj: str, expected: bool,
+    ):
+        assert base_graph.is_child_of_or_equal_to(
+            sub, obj,
+        ) is expected
+
+    @pytest.mark.parametrize(
+        'sub, obj, expected',
+        [
+            ('HP:1', 'HP:1', True),
+            ('HP:01', 'HP:1', True),
+            ('HP:010', 'HP:1', True),
+        ]
+    )
+    def test_is_descendant_of_or_equal_to(
+        self,
+        base_graph: OntologyGraph,
+        sub: str, obj: str, expected: bool,
+    ):
+        assert base_graph.is_descendant_of_or_equal_to(
+            sub, obj,
+        ) is expected
+
+
 @ddt.ddt
 class TestCsrOntologyGraph(unittest.TestCase):
     """

--- a/src/hpotk/ontology/__init__.py
+++ b/src/hpotk/ontology/__init__.py
@@ -4,9 +4,10 @@ The `hpotk.ontology` package defines what an ontology is and provides methods fo
 
 from ._api import MinimalOntology, Ontology
 from ._default import create_minimal_ontology, create_ontology
-from . import load
 
 __all__ = [
-    'MinimalOntology', 'Ontology',
-    'create_minimal_ontology', 'create_ontology'
+    "MinimalOntology",
+    "Ontology",
+    "create_minimal_ontology",
+    "create_ontology",
 ]

--- a/src/hpotk/ontology/_api.py
+++ b/src/hpotk/ontology/_api.py
@@ -139,7 +139,7 @@ class MinimalOntology(typing.Generic[ID, MINIMAL_TERM], GraphAware[ID], Versione
         return self.get_term(term_id) is not None
 
     @abc.abstractmethod
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Get the number of the primary (non-obsolete) terms in the ontology.
         

--- a/src/hpotk/ontology/_default.py
+++ b/src/hpotk/ontology/_default.py
@@ -79,7 +79,7 @@ class DefaultOntology(Ontology[ID, TERM]):
     def version(self) -> typing.Optional[str]:
         return self._version
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._current_terms)
 
 

--- a/src/hpotk/ontology/load/__init__.py
+++ b/src/hpotk/ontology/load/__init__.py
@@ -1,1 +1,1 @@
-from . import obographs
+

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,29 @@
+class TestHpoBase:
+    def test_phenotypic_abnormality(self):
+        from hpotk.constants.hpo.base import PHENOTYPIC_ABNORMALITY
+
+        assert PHENOTYPIC_ABNORMALITY.value == "HP:0000118"
+
+    def test_mode_of_inheritance(self):
+        from hpotk.constants.hpo.base import MODE_OF_INHERITANCE
+
+        assert MODE_OF_INHERITANCE.value == "HP:0000005"
+
+
+class TestHpoFrequency:
+    def test_frequencies(self):
+        from hpotk.constants.hpo.frequency import (
+            EXCLUDED,
+            VERY_RARE,
+            OCCASIONAL,
+            FREQUENT,
+            VERY_FREQUENT,
+            OBLIGATE,
+        )
+
+        assert EXCLUDED.value == "HP:0040285"
+        assert VERY_RARE.value == "HP:0040284"
+        assert OCCASIONAL.value == "HP:0040283"
+        assert FREQUENT.value == "HP:0040282"
+        assert VERY_FREQUENT.value == "HP:0040281"
+        assert OBLIGATE.value == "HP:0040280"


### PR DESCRIPTION
Add support for hierarchy queries that test if a term is equal to or parent/ancestor/child/descendant of another term.

Fix a bunch of lints.